### PR TITLE
[DRAFT] Generate scripts programmatically using Nix

### DIFF
--- a/bin/default.nix
+++ b/bin/default.nix
@@ -1,0 +1,101 @@
+{
+  # nix support
+  stdenvNoCC,
+  stdenv,
+  buildFHSEnv,
+  writeShellScript,
+  lib,
+  env,
+
+  # git commit of self (will be "unstable" if working tree dirty)
+  rev,
+
+  # git repos
+  arcturus-tree,
+  ros2-keyboard,
+
+  # build tools
+  ros2nix,
+  colcon,
+  git,
+}:
+let
+  # Run this script after `pull.sh` (in this directory) from inside a Nix development shell.
+  # It will build the relevant Nix package manifests.
+  # You can run this again to rebuild Nix packages if dependencies change, e.g.
+  # add other ROS packages here
+  scripts = lib.attrsToList rec {
+    # Run this script initially (in this directory) from inside a Nix development shell.
+    # It will create a workspace `dev_ws` in the current directory.
+    # The version of `all_seaing_vehicle` is the one specified or the latest revision by default.
+    # Only run this script once and use `./build.sh` after.
+    # Dependencies will intentionally not be updated to ensure reproducibility.
+    pull = writeShellScript "pull.sh" ''
+      # dynamically inject the hash from flake
+      ref=''${1:-"${arcturus-tree.rev}"}
+
+      # create a workspace
+      echo -e "\e[1mCreating a workspace for all_seaing_vehicle and dependencies in dev_ws/src\e[0m"
+      echo "====="
+      mkdir -p ./dev_ws/src
+      echo -e "\e[1mDone creating workspaces.\e[0m"
+
+      # clone all_seaing_vehicle
+      echo -e "\e[1mCloning all_seaing_vehicle\e[0m"
+      echo "====="
+      cd ./dev_ws/src
+      # we could get this from the flake, but we want to be able to hack on
+      # code so this is a compromise
+      ${git}/bin/git clone https://github.com/ArcturusNavigation/all_seaing_vehicle
+      cd all_seaing_vehicle
+      ${git}/bin/git checkout $ref
+      cd ..
+      echo -e "Done cloning all_seaing_vehicle."
+
+      # use latest commit (no version tag) of ros2-keyboard
+      echo -e "\e[1mLinking ros2-keyboard (f1d8412)\e[0m"
+
+      # link the ros2-keyboard version pinned in our flake to the directory
+      ln -s ${ros2-keyboard} ros2-keyboard
+
+      echo -e "\e[1mDone fetching repositories.\e[0m"
+      echo -e "\e[1mUse \`./build.sh\` before running your first node.\e[0m"
+    '';
+
+    # Run this script initially (in this directory) from inside a Nix development shell.
+    # It will create a workspace `dev_ws` in the current directory.
+    # Only run this script once and use `. ./run.sh` after.
+    # Dependencies will intentionally not be updated to ensure reproducibility.
+    # install = writeShellScript "install.sh" ''
+    #   ${pull}
+    #   ${build}
+    # '';
+  };
+in
+stdenvNoCC.mkDerivation {
+  pname = "arcturus-scripts";
+  version = rev;
+
+  phases = [
+    "installPhase"
+    "fixupPhase"
+  ];
+
+  buildInputs = [
+    git
+    ros2nix
+    colcon
+  ];
+
+  installPhase =
+    ''
+      mkdir -p $out/bin
+    ''
+    + builtins.concatStringsSep "\n" (builtins.map (x: "ln -s ${x.value} $out/bin/${x.name}") scripts);
+
+  meta = {
+    maintainers = [ lib.maintainers.youwen5 ];
+    platforms = lib.platforms.linux;
+    mainProgram = "install";
+  };
+}

--- a/bin/default.nix
+++ b/bin/default.nix
@@ -59,6 +59,39 @@ let
       echo -e "\e[1mUse \`./build.sh\` before running your first node.\e[0m"
     '';
 
+    source = writeShellScript "source.sh" ''
+      # main routine
+      main() {
+      	# source manifests
+      	cd dev_ws
+      	echo -e "\e[1mAdding all modules to ROS environment.\e[0m"
+      	dirs=($(
+      		cd install
+      		ls -d */ | sed 's:/$::'
+      	))
+      	for dir in "''${dirs[@]}"; do
+      		path="install/''${dir}/share/''${dir}/local_setup.bash"
+      		if [[ -f "$path" ]]; then
+      			source $path
+      		fi
+      	done
+      	echo "Done adding all modules to ROS environment."
+      	cd ..
+      }
+
+      # show help and exit
+      if [[ "$1" == "-h" || "$1" == "--help" ]]; then
+      	echo -e "\e[1mUsage\e[0m: . ./source.sh [-h]"
+      	echo -e "\e[1mNote\e[0m: You can run nodes within a module with \`ros2 run module_name node.py\` after using this script."
+      	echo -e "\e[1mImportant\e[0m: Use a period (.) before the script name so that environment changes occur in your current shell session."
+      	echo -e "Sources necessary build files from ."
+      	echo -e "Run from root directory (dev_ws/install/ should be a subdirectory)."
+      else
+      	main
+      fi
+
+    '';
+
     # Run this script initially (in this directory) from inside a Nix development shell.
     # It will create a workspace `dev_ws` in the current directory.
     # Only run this script once and use `. ./run.sh` after.

--- a/bin/default.nix
+++ b/bin/default.nix
@@ -62,14 +62,16 @@ let
       echo -e "\e[1mUse \`./build.sh\` before running your first node.\e[0m"
     '';
 
+    build = "${env}/bin/arcturus-builder";
+
     # Run this script initially (in this directory) from inside a Nix development shell.
     # It will create a workspace `dev_ws` in the current directory.
     # Only run this script once and use `. ./run.sh` after.
     # Dependencies will intentionally not be updated to ensure reproducibility.
-    # install = writeShellScript "install.sh" ''
-    #   ${pull}
-    #   ${build}
-    # '';
+    install = writeShellScript "install.sh" ''
+      ${pull}
+      ${build}
+    '';
   };
 in
 stdenvNoCC.mkDerivation {

--- a/bin/default.nix
+++ b/bin/default.nix
@@ -92,6 +92,18 @@ let
 
     '';
 
+    get-versions = writeShellScript "get-versions.sh" ''
+      echo -e "\e[1mgithub:ArcturusNavigation/arcturus_nix\e[0m"
+      if [ "${rev}" == 'unstable' ]; then
+        echo 'your working tree is dirty, you have uncommitted changes.'
+      else
+        echo 'commit: ${rev}'
+      fi
+
+      echo -e "\n\e[1mgithub:ArcturusNavigation/all_seaing_vehicle\e[0m"
+      echo 'commit: ${arcturus-tree.rev}'
+    '';
+
     # Run this script initially (in this directory) from inside a Nix development shell.
     # It will create a workspace `dev_ws` in the current directory.
     # Only run this script once and use `. ./run.sh` after.

--- a/bin/default.nix
+++ b/bin/default.nix
@@ -1,11 +1,8 @@
 {
   # nix support
   stdenvNoCC,
-  stdenv,
-  buildFHSEnv,
   writeShellScript,
   lib,
-  env,
 
   # git commit of self (will be "unstable" if working tree dirty)
   rev,

--- a/bin/default.nix
+++ b/bin/default.nix
@@ -133,11 +133,12 @@ stdenvNoCC.mkDerivation {
     ''
       mkdir -p $out/bin
     ''
-    + builtins.concatStringsSep "\n" (builtins.map (x: "ln -s ${x.value} $out/bin/${x.name}") scripts);
+    + builtins.concatStringsSep "\n" (
+      builtins.map (x: "ln -s ${x.value} $out/bin/arcturus-${x.name}") scripts
+    );
 
   meta = {
     maintainers = [ lib.maintainers.youwen5 ];
     platforms = lib.platforms.linux;
-    mainProgram = "install";
   };
 }

--- a/bin/default.nix
+++ b/bin/default.nix
@@ -62,16 +62,14 @@ let
       echo -e "\e[1mUse \`./build.sh\` before running your first node.\e[0m"
     '';
 
-    build = "${env}/bin/arcturus-builder";
-
     # Run this script initially (in this directory) from inside a Nix development shell.
     # It will create a workspace `dev_ws` in the current directory.
     # Only run this script once and use `. ./run.sh` after.
     # Dependencies will intentionally not be updated to ensure reproducibility.
-    install = writeShellScript "install.sh" ''
-      ${pull}
-      ${build}
-    '';
+    # install = writeShellScript "install.sh" ''
+    #   ${pull}
+    #   ${build}
+    # '';
   };
 in
 stdenvNoCC.mkDerivation {

--- a/build.sh
+++ b/build.sh
@@ -1,6 +1,8 @@
-# $ nix develop
-# <devshell> $ ./build.sh
+#!/usr/bin/env -S nix develop .#dev --command bash
 
+# IMPORTANT: This script MUST be run from somewhere within the arcturus_nix
+# project directory, or it will not work!
+#
 # Run this script after `pull.sh` (in this directory) from inside a Nix development shell.
 # It will build the relevant Nix package manifests.
 # You can run this again to rebuild Nix packages if dependencies change, e.g.

--- a/flake.lock
+++ b/flake.lock
@@ -1,5 +1,22 @@
 {
   "nodes": {
+    "arcturus-tree": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1736713641,
+        "narHash": "sha256-8gT1YuF3cXhTaHXrahYQMcdamV/wi7+TNoftzWM9E5g=",
+        "owner": "ArcturusNavigation",
+        "repo": "all_seaing_vehicle",
+        "rev": "e16e44c8a35bdaa9a0468624e0cc4b2b5fd377fa",
+        "type": "github"
+      },
+      "original": {
+        "owner": "ArcturusNavigation",
+        "ref": "q9i/nix-launch",
+        "repo": "all_seaing_vehicle",
+        "type": "github"
+      }
+    },
     "flake-compat": {
       "flake": false,
       "locked": {
@@ -218,13 +235,31 @@
     },
     "root": {
       "inputs": {
+        "arcturus-tree": "arcturus-tree",
         "nix-ros-overlay": "nix-ros-overlay",
         "nixpkgs": [
           "nix-ros-overlay",
           "nixpkgs"
         ],
         "pre-commit-hooks": "pre-commit-hooks",
+        "ros2-keyboard": "ros2-keyboard",
         "ros2nix": "ros2nix"
+      }
+    },
+    "ros2-keyboard": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1725801693,
+        "narHash": "sha256-xgPr7tsho48emUh0ggb1P84lEHm8tt+Byo8xlprYUVQ=",
+        "owner": "cmower",
+        "repo": "ros2-keyboard",
+        "rev": "f1d84122b40cbeec05d54ce90d35c8d16b47bbad",
+        "type": "github"
+      },
+      "original": {
+        "owner": "cmower",
+        "repo": "ros2-keyboard",
+        "type": "github"
       }
     },
     "ros2nix": {

--- a/flake.nix
+++ b/flake.nix
@@ -140,8 +140,12 @@
 
         formatter = pkgs.nixfmt-rfc-style;
 
-        packages = {
-          default = pkgs.callPackage ./bin {
+        packages = rec {
+          default = pkgs.symlinkJoin {
+            name = "arcturus-tools";
+            paths = [ arcturus-scripts ];
+          };
+          arcturus-scripts = pkgs.callPackage ./bin {
             inherit arcturus-tree ros2-keyboard;
             inherit (ros2nix.packages.${pkgs.stdenv.targetPlatform.system}) ros2nix;
             rev = if (self ? rev) then self.rev else "unstable";

--- a/flake.nix
+++ b/flake.nix
@@ -8,6 +8,16 @@
 
     # for development
     pre-commit-hooks.url = "github:cachix/pre-commit-hooks.nix";
+
+    arcturus-tree = {
+      url = "github:ArcturusNavigation/all_seaing_vehicle/q9i/nix-launch";
+      flake = false;
+    };
+
+    ros2-keyboard = {
+      url = "github:cmower/ros2-keyboard";
+      flake = false;
+    };
   };
   outputs =
     {
@@ -16,6 +26,8 @@
       ros2nix,
       nixpkgs,
       pre-commit-hooks,
+      arcturus-tree,
+      ros2-keyboard,
     }:
     nix-ros-overlay.inputs.flake-utils.lib.eachDefaultSystem (
       system:
@@ -127,6 +139,14 @@
         };
 
         formatter = pkgs.nixfmt-rfc-style;
+
+        packages = {
+          default = pkgs.callPackage ./bin {
+            inherit arcturus-tree ros2-keyboard;
+            inherit (ros2nix.packages.${pkgs.stdenv.targetPlatform.system}) ros2nix;
+            rev = if (self ? rev) then self.rev else "unstable";
+          };
+        };
       }
     );
   nixConfig = {

--- a/flake.nix
+++ b/flake.nix
@@ -140,93 +140,12 @@
 
         formatter = pkgs.nixfmt-rfc-style;
 
-        packages = rec {
+        packages = {
           default = pkgs.callPackage ./bin {
-            inherit arcturus-tree ros2-keyboard env;
+            inherit arcturus-tree ros2-keyboard;
             inherit (ros2nix.packages.${pkgs.stdenv.targetPlatform.system}) ros2nix;
             rev = if (self ? rev) then self.rev else "unstable";
-
           };
-          env = (
-            with pkgs.rosPackages.humble;
-            (buildEnv {
-              paths = [
-                # empirically determined list of project ROS dependencies
-                ros-core
-                boost
-                ament-cmake-core
-                angles
-                diagnostic-updater
-                geographic-msgs
-                message-filters
-                tf-transformations
-                tf2-ros-py
-                tf2-eigen
-                tf2-geometry-msgs
-                yaml-cpp-vendor
-                python-cmake-module
-                rviz-common
-                tf2-sensor-msgs
-                mavros-msgs
-                pcl-ros
-                cv-bridge
-                image-geometry
-                rviz-satellite
-                rviz-default-plugins
-                rosbag2-py
-
-                # for simulation (requires insecure packages)
-                # gazebo-ros
-
-                # for launch
-                mavros
-                robot-localization
-                velodyne-pointcloud
-
-                # add other ROS packages here
-              ];
-            }).overrideAttrs
-              (prev: {
-                buildPhase =
-                  prev.buildPhase
-                  + ''
-                    cat << EOF > build.sh
-
-                    # generate package manifests
-                    echo -e "\e[1mGenerating Nix packages for all_seaing_vehicle and dependencies with ros2nix\e[0m"
-                    echo "====="
-                    cd dev_ws
-                    ${ros2nix}/bin/ros2nix -- \$(find -name package.xml)
-                    echo -e "Done generating Nix packages."
-
-                    # create build artifacts
-                    echo -e "\e[1mGenerating build artifacts and symlinks for ROS.\e[0m"
-                    echo "====="
-                    ${pkgs.colcon}/bin/colcon build --symlink-install
-                    cd ..
-                    echo -e "Done generating build artifacts and symlinks for ROS."
-
-                    echo -e "\e[1mDone installing.\e[0m"
-                    echo -e "\e[1mUse \`. run.sh module_name node.py\` to build your first node.\e[0m"
-                    EOF
-
-                    install -Dm755 build.sh $out/bin/arcturus-builder
-
-                    makeWrapper "$out/bin/arcturus-builder" "$out/bin/arcturus-builder-wrapped" \
-                      --prefix PATH : "$out/bin" \
-                      --prefix LD_LIBRARY_PATH : "$out/lib:${pkgs.lib.makeLibraryPath [ pkgs.openssl.out ]}" \
-                      --prefix PYTHONPATH : "$out/${pkgs.python.sitePackages}" \
-                      --prefix CMAKE_PREFIX_PATH : "$out" \
-                      --prefix AMENT_PREFIX_PATH : "$out" \
-                      --prefix ROS_PACKAGE_PATH : "$out/share" \
-                      --prefix GZ_CONFIG_PATH : "$out/share/gz" \
-                      --set ROS_DISTRO '${ros-environment.rosDistro}' \
-                      --set ROS_VERSION '${toString ros-environment.rosVersion}' \
-                      --set ROS_PYTHON_VERSION '${lib.versions.major python.version}' \
-                      ''${rosWrapperArgs[@]}
-                  '';
-              })
-          );
         };
       }
     );


### PR DESCRIPTION
This MR is not yet ready but I'm opening it as a draft to make it visible to upstream. Currently we can generate all pure scripts directly using Nix (here pure refers to not relying on any transient machine state). Prominently, the `build.sh` script and `source.sh` scripts are _not_ pure so we cannot generate those directly.

The current plan is to write a pure configure script (e.g. `arcturus-configure`) that copies these scripts into the correct location when ran. This script could be ran manually, or as a devshell enterHook. This way we can still avoid configuration drifts between the shell scripts and Nix while allowing impure build scripts to be generated. The end goal of course is to make _all_ scripts pure, so this is a stopgap solution.